### PR TITLE
Moving error handler to close event rather than error.

### DIFF
--- a/websocket.js
+++ b/websocket.js
@@ -78,5 +78,5 @@ module.exports = class WebSocketStream extends Duplex {
 }
 
 function eventToError (event) {
-  return new Error(`Websocket closed[${event.code}] (reason="${event.reason}", clean=${event.wasClean})`)
+  return new Error(`Websocket[url=${event.target.url}] closed[${event.code}] (reason="${event.reason}", clean=${event.wasClean})`)
 }


### PR DESCRIPTION
Trying to debug a web setup I came across this error message:

> Error: [Object object]

Which was caused by webnet, trying to close a stream with the browsers [error `Event`][error-evt] object, which isn't an Error. In this PR, the [close event][close-evt] is instead used, as it is more descriptive, containing possible a "reason" property and close code, allowing to inspect the reason why it was closed and also being informative on the error stack, which helps debugging.

[error-evt]: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/error_event
[close-evt]: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent